### PR TITLE
condensed service to single token endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ response:
 ```
 
 ### Token ###
-The token endpoint requires a `channelName`, and the user's `uid` to generate both RTC and RTM tokens. 
+The token endpoint requires a `channelName`, the user's `role` (subscriber/publisher), and the user's `uid` to generate both RTC and RTM tokens. 
 `(optional)` Pass an integer to represent the token privilege lifetime in seconds.
 
 **endpoint structure** 
 ```
-/token/:channelName/:uid/?expireTime
+/token/:channelName/:role/:uid/?expireTime
 ```
 
 response:

--- a/README.md
+++ b/README.md
@@ -41,29 +41,19 @@ response:
 {"message":"pong"} 
 ```
 
-### RTC Token ###
-The `rtc` token endpoint requires a `tokentype` (uid || userAccount), `channelName`, and the user's `uid` (type varies based on `tokentype`). 
-`(optional)` Pass an integer to represent the token lifetime in seconds.
+### Token ###
+The token endpoint requires a `channelName`, and the user's `uid` to generate both RTC and RTM tokens. 
+`(optional)` Pass an integer to represent the token privilege lifetime in seconds.
 
 **endpoint structure** 
 ```
-/rtc/:tokentype/:channelName/:uid/?expireTime
+/token/:channelName/:uid/?expireTime
 ```
 
 response:
 ``` 
-{"token":" "} 
-```
-
-## RTM ##
-The `rtm` token endpoint requires the user's `uid`. 
-`(optional)` Pass an integer to represent the privelege lifetime in seconds.
-**endpoint structure** 
-```
-/rtm/:uid/?expireTime
-```
-
-response:
-``` 
-{"token":" "} 
+{
+  "rtcToken":" ",
+  "rtmToken":" ",
+} 
 ```

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 
 	appID, appIDExists := os.LookupEnv("APP_ID")
-	appCertificate, appCertExists := os.LookupEnv("APP_CERT")
+	appCertificate, appCertExists := os.LookupEnv("APP_CERTIFICATE")
 
 	if !appIDExists || !appCertExists {
 		log.Fatal("FATAL ERROR: ENV not properly configured, check appID and appCertificate")
@@ -30,18 +30,20 @@ func main() {
 	})
 
 	// This handler will match  with or without a tokentype
-	api.GET("rtc/:tokentype/:channelName/:uid/", func(c *gin.Context) {
+	api.GET("/token/:channelName/:uid/", func(c *gin.Context) {
 		// get param values
 		channelName := c.Param("channelName")
 		uidStr := c.Param("uid")
-		tokentype := c.Param("tokentype")
 		expireTime := c.DefaultQuery("expiry", "3600")
 
-		log.Printf("tokentype: %s\n", tokentype)
-
 		// declare vars
-		var result string // token string
-		var err error     // catch-all error
+		var rtcToken, rtmToken string // token strings
+		var err error                 // catch-all error
+
+		// check if uid is set to 0
+		if uidStr == "0" {
+			uidStr = ""
+		}
 
 		expireTime64, err := strconv.ParseUint(expireTime, 10, 64)
 		// check if string conversion fails
@@ -59,32 +61,18 @@ func main() {
 		currentTimestamp := uint32(time.Now().UTC().Unix())
 		expireTimestamp := currentTimestamp + expireTimeInSeconds
 
-		if tokentype == "uid" {
-			uid64, err := strconv.ParseUint(uidStr, 10, 64)
-			// check if string conversion fails
-			if err != nil {
-				c.Error(err)
-				c.AbortWithStatusJSON(400, gin.H{
-					"message": "UID conversion error",
-					"status":  400,
-				})
-				return
-			}
-			uid := uint32(uid64) // convert uid from uint64 to uint 32
-			log.Printf("\nBuilding Token with uid: %d\n", uid)
-			result, err = rtctokenbuilder.BuildTokenWithUID(appID, appCertificate, channelName, uid, rtctokenbuilder.RoleAttendee, expireTimestamp)
-		} else if tokentype == "userAccount" {
-			log.Printf("\nBuilding Token with userAccount: %s\n", uidStr)
-			result, err = rtctokenbuilder.BuildTokenWithUserAccount(appID, appCertificate, channelName, uidStr, rtctokenbuilder.RoleAttendee, expireTimestamp)
-		} else {
-			errMsg := "Unknown Tokentype: " + tokentype
-			log.Println(errMsg)
+		rtcToken, err = rtctokenbuilder.BuildTokenWithUserAccount(appID, appCertificate, channelName, uidStr, rtctokenbuilder.RoleAttendee, expireTimestamp)
+
+		if err != nil {
+			log.Println(err) // token failed to generate
+			c.Error(err)
 			c.AbortWithStatusJSON(400, gin.H{
+				"error":  err,
 				"status": 400,
-				"error":  errMsg,
 			})
-			return
 		}
+
+		rtmToken, err = rtmtokenbuilder.BuildToken(appID, appCertificate, uidStr, rtmtokenbuilder.RoleRtmUser, expireTimestamp)
 
 		if err != nil {
 			log.Println(err) // token failed to generate
@@ -96,55 +84,13 @@ func main() {
 		} else {
 			log.Println("Token generated")
 			c.JSON(200, gin.H{
-				"token": result,
+				"rtcToken": rtcToken,
+				"rtmToken": rtmToken,
 			})
 		}
 
 	})
 
-	api.GET("rtm/:uid/", func(c *gin.Context) {
-		// get param values
-		uidStr := c.Param("uid")
-		expireTime := c.DefaultQuery("expiry", "3600")
-
-		log.Printf("rtm token\n")
-
-		// declare vars
-		var result string // token string
-		var err error     // catch-all error
-
-		expireTime64, err := strconv.ParseUint(expireTime, 10, 64)
-		// check if string conversion fails
-		if err != nil {
-			c.Error(err)
-			c.AbortWithStatusJSON(400, gin.H{
-				"message": "expireTime conversion error",
-				"status":  400,
-			})
-			return
-		}
-
-		// set timestamps
-		expireTimeInSeconds := uint32(expireTime64)
-		currentTimestamp := uint32(time.Now().UTC().Unix())
-		expireTimestamp := currentTimestamp + expireTimeInSeconds
-
-		result, err = rtmtokenbuilder.BuildToken(appID, appCertificate, uidStr, rtmtokenbuilder.RoleRtmUser, expireTimestamp)
-
-		if err != nil {
-			log.Println(err) // token failed to generate
-			c.Error(err)
-			c.AbortWithStatusJSON(400, gin.H{
-				"error":  err,
-				"status": 400,
-			})
-		} else {
-			log.Println("Token generated")
-			c.JSON(200, gin.H{
-				"token": result,
-			})
-		}
-
-	})
-	api.Run(":8080") // listen and serve on localhost:8080
+	// listen and serve on localhost:8080
+	api.Run(":8080")
 }

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func main() {
 				"error":  err,
 				"status": 400,
 			})
+			return
 		}
 
 		rtmToken, err = rtmtokenbuilder.BuildToken(appID, appCertificate, uidStr, rtmtokenbuilder.RoleRtmUser, expireTimestamp)


### PR DESCRIPTION
Original microservice used 3 endpoints (2 for rtc and 1 for rtm) to generate tokens. 

Under the hood rtc with UID is the same as rtc with user account, so to simplify the process I removed the UID endpoint and using a single rtc with User account to generate the rtc token.

In most instances users will need both rtc and rtm tokens so it makes more sense to generate both with a single endpoint than to require the user to make separate calls that parse the same data. This is redundant and inefficient, so I merged both rtc and rtm token generation into a single endpoint.