### PR TITLE
Corrected deploy to Heroku link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Written in Golang, using [Gin framework](https://github.com/gin-gonic/gin) to cr
 Agora.io Advanced Guide: [Token Management](https://docs.agora.io/en/Video/token_server_cpp?platform=CPP)
 
 ## Deploy to Heroku ##
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy/?template=https://github.com/AgoraIO-Community/agora-token-service)
 
 ## How to Run ##
 Set the APP_ID and APP_CERTIFICATE env variables.


### PR DESCRIPTION
The previous link was just a button link. The GitHub repo's URL wasn't entered before making the button non-functional.