### PR TITLE
Update render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -11,5 +11,4 @@ services:
       - key: APP_CERTIFICATE
         sync: false
       - key: CORS_ALLOW_ORIGIN
-        sync: false
         value: "*"


### PR DESCRIPTION
![image](https://github.com/AgoraIO-Community/agora-token-service/assets/10047883/b1b14ea1-ea99-457a-bd31-a31d5351135c)
Render doesn't support using value and sync at the same time, should we just use `"*"`?