### PR TITLE
Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,15 @@
 FROM golang:alpine
 RUN apk add git ca-certificates --update
 
-# fetch dependencies github
-# RUN go get -u github.com/gin-gonic/gin
-
+# Copy Go src code
 ADD . /go/src/github.com/AgoraIO-Community/agora-token-service
 
-# # fetch dependencies from github (Gin and Agora Token Service)
-# RUN go install github.com/gin-gonic/gin@latest
-# # RUN go install github.com/AgoraIO-Community/agora-token-service
-# ADD . /go/src/github.com/AgoraIO-Community/agora-token-service
-
+# Declare build-time ARGs and set them as persistant ENV variables
 ARG APP_ID
 ARG APP_CERTIFICATE
 ARG SERVER_PORT
 ARG CORS_ALLOW_ORIGIN
+
 ENV APP_ID $APP_ID
 ENV APP_CERTIFICATE $APP_CERTIFICATE
 ENV SERVER_PORT $SERVER_PORT
@@ -24,9 +19,10 @@ ENV CORS_ALLOW_ORIGIN $CORS_ALLOW_ORIGIN
 
 # move to the working directory
 WORKDIR $GOPATH/src/github.com/AgoraIO-Community/agora-token-service
+
 # Build the token server command inside the container.
 RUN go build -o agora-token-service -v cmd/main.go
-# RUN go run main.go
+
 # Run the token server by default when the container starts.
 ENTRYPOINT ./agora-token-service
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ ADD . /go/src/github.com/AgoraIO-Community/agora-token-service
 ARG APP_ID
 ARG APP_CERTIFICATE
 ARG SERVER_PORT
+ARG CORS_ALLOW_ORIGIN
 ENV APP_ID $APP_ID
 ENV APP_CERTIFICATE $APP_CERTIFICATE
 ENV SERVER_PORT $SERVER_PORT
+ENV CORS_ALLOW_ORIGIN $CORS_ALLOW_ORIGIN
 
 # move to the working directory
 WORKDIR $GOPATH/src/github.com/AgoraIO-Community/agora-token-service
@@ -29,4 +31,4 @@ RUN go build -o agora-token-service -v cmd/main.go
 ENTRYPOINT ./agora-token-service
 
 # Document that the service listens on port 8080.
-EXPOSE 8080
+EXPOSE $SERVER_PORT

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+SHELL := /bin/bash
+
+TAG_SHA = agora-token-service
+
+# set the build args from env file
+DECONARGS = $(shell echo "$$(for i in `cat .env`; do out+="--build-arg $$i " ; done; echo $$out;out="")")
+# Generate the Arguments using DECONARGS
+GEN_ARGS = $(eval BARGS=$(DECONARGS))
+# Set the SERVER_PORT from .env, run target checks if set and defaults to 8080 if needed
+SERVER_PORT = $(shell grep SERVER_PORT .env | cut -d '=' -f2 | tr -d '[:space:]' || echo "8080")
+
+# Docker and Golang source files
+DOCKER_FILES := Dockerfile
+GO_SOURCE_FILEs := $(shell find . -type f -name '*.go')
+
+
+.PHONY: all check-env build run clean
+
+all: build run
+
+check-env: 
+	@if [ ! -f .env ]; then \
+		echo ".env file not found. Please create one."; \
+		exit 1;\
+	fi
+
+build_marker: $(DOCKER_FILES) $(GO_SOURCE_FILEs) .env
+	@echo "Running docker build with tag: ${TAG_SHA}"
+		$(GEN_ARGS)
+	docker build -t $(TAG_SHA) $(BARGS) .
+	@touch build_marker
+
+build: check-env build_marker
+
+run: 
+	@SERVER_PORT=$${SERVER_PORT:-8080}; \
+	echo "Running docker container on port: $$SERVER_PORT"; \
+	docker run -p $$SERVER_PORT:$$SERVER_PORT agora-token-service
+
+clean:
+	rm -f build_marker

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The pre-compiled binaries are also available in [releases](https://github.com/Ag
 
 ## Docker ##
 
-#1. To build the container, with app id and certificate: 
+#1. To build the container with app id and certificate: 
 
 ```bash
 docker build -t agora-token-service --build-arg APP_ID=$APP_ID --build-arg APP_CERTIFICATE=$APP_CERTIFICATE --build-arg CORS_ALLOW_ORIGIN=$ALLOWED_ORIGINS .
@@ -54,6 +54,22 @@ docker run agora-token-service
 > Note: for testing locally
 ```bash
 docker run -p 8080:8080 agora-token-service
+```
+
+## Makefile ##
+Build and run the docker container using `make`. The `Makefile` simplifies the build and run process by reducing them to a single command. The `Makefile` uses the `.env` file to add the `--buildArgs` and excutes the run command after build is completed. To avoid unnecessary rebuilds of the token server, the `Makefile` sets a `build_marker` target to watch the dockerfile, `.go` source code, and `.env` file. This enables a single command to build and run the container that only rebuilds as needed.
+
+#1. Set the APP_ID, and APP_CERTIFICATE as env variables. Optionaly SERVER_PORT and CORS_ALLOW_ORIGIN can also be set as env variables, but they not required and there are defaults if they are not detected.
+```bash
+cp .env.example .env
+```
+#2. Run `make`
+```bash
+make
+```
+Execute the `cleanup` target to force a rebuild:
+```bash
+make cleanup
 ```
 
 ## Endpoints ##

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ docker run -p 8080:8080 agora-token-service
 ```
 
 ## Makefile ##
-Build and run the docker container using `make`. The `Makefile` simplifies the build and run process by reducing them to a single command. The `Makefile` uses the `.env` file to add the `--buildArgs` and excutes the run command after build is completed. To avoid unnecessary rebuilds of the token server, the `Makefile` sets a `build_marker` target to watch the dockerfile, `.go` source code, and `.env` file. This enables a single command to build and run the container that only rebuilds as needed.
+Build and run the docker container using `make`. The `Makefile` simplifies the build and run process by reducing them to a single command. The `Makefile` uses the `.env` file to add the list of `--build-arg`'s to the `docker build` command and executes the `docker run` command after the build is completed. To avoid unnecessary rebuilds of the token server, the `Makefile` sets a `build_marker` target to watch the dockerfile, `.go` source code, and `.env` file. This enables a single command to build and run the container that only rebuilds as needed.
 
 #1. Set the APP_ID, and APP_CERTIFICATE as env variables. Optionaly SERVER_PORT and CORS_ALLOW_ORIGIN can also be set as env variables, but they not required and there are defaults if they are not detected.
 ```bash

--- a/service/service.go
+++ b/service/service.go
@@ -65,6 +65,8 @@ func NewService() *Service {
 	appIDEnv, appIDExists := os.LookupEnv("APP_ID")
 	appCertEnv, appCertExists := os.LookupEnv("APP_CERTIFICATE")
 	serverPort, serverPortExists := os.LookupEnv("SERVER_PORT")
+	corsAllowOrigin, _ := os.LookupEnv("CORS_ALLOW_ORIGIN")
+
 	if !appIDExists || !appCertExists || len(appIDEnv) == 0 || len(appCertEnv) == 0 {
 		log.Fatal("FATAL ERROR: ENV not properly configured, check .env file or APP_ID and APP_CERTIFICATE")
 	}
@@ -77,7 +79,6 @@ func NewService() *Service {
 			serverPort = "8080"
 		}
 	}
-	corsAllowOrigin, _ := os.LookupEnv("CORS_ALLOW_ORIGIN")
 
 	s := &Service{
 		Sigint: make(chan os.Signal, 1),


### PR DESCRIPTION
Updated [`Dockerfile`](https://github.com/AgoraIO-Community/agora-token-service/blob/makefile/Dockerfile) 
- to support CORS_ALLOW_ORIGIN as a `--build-arg` 
- to use SERVER_PORT as the port exposed (previously was always set to 8080)

Added [`Makefile`](https://github.com/AgoraIO-Community/agora-token-service/blob/makefile/Makefile) to simplify the build process. 
- **Issue:** The build process is a bit complex/confusing with setting `.env` for test the server with Go, to passing `--build-arg` for each environment variable. 
- **Solution:** Use make to streamline the process.  The Makefile simplifies the build and run process by reducing them to a single command. The `Makefile` uses the` .env` file to add the list of `--build-arg`'s to the `docker build` command and executes the `docker run` command after the build is completed. To avoid unnecessary rebuilds of the token server, the `Makefile` sets a `build_marker` target to watch the `Dockerfile`, `.go` source code, and `.env` file. This enables a single command to build and run the container that only rebuilds as needed.
