### PR TITLE
added preflight support

### DIFF
--- a/service/http_handlers.go
+++ b/service/http_handlers.go
@@ -3,6 +3,8 @@ package service
 import (
 	"fmt"
 	"log"
+	"net/http"
+	"strings"
 
 	rtmtokenbuilder2 "github.com/AgoraIO-Community/go-tokenbuilder/rtmtokenbuilder"
 
@@ -153,8 +155,43 @@ func (s *Service) nocache() gin.HandlerFunc {
 		c.Header("Cache-Control", "private, no-cache, no-store, must-revalidate")
 		c.Header("Expires", "-1")
 		c.Header("Pragma", "no-cache")
-		if s.allowOrigin != "" {
-			c.Header("Access-Control-Allow-Origin", s.allowOrigin)
+	}
+}
+
+// Add CORSMiddleware to handle CORS requests and set the necessary headers
+func (s *Service) CORSMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+		if !s.isOriginAllowed(origin) {
+			c.Header("Content-Type", "application/json")
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "Origin not allowed",
+			})
+			c.Abort()
+			return
+		}
+		c.Header("Access-Control-Allow-Origin", origin)
+		c.Header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		c.Header("Access-Control-Allow-Headers", "Origin, Content-Type")
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+		c.Next()
+	}
+}
+
+func (s *Service) isOriginAllowed(origin string) bool {
+	if s.allowOrigin == "*" {
+		return true
+	}
+
+	allowedOrigins := strings.Split(s.allowOrigin, ",")
+	for _, allowed := range allowedOrigins {
+		if origin == allowed {
+			return true
 		}
 	}
+
+	return false
 }

--- a/service/service.go
+++ b/service/service.go
@@ -93,6 +93,7 @@ func NewService() *Service {
 	api := gin.Default()
 
 	api.Use(s.nocache())
+	api.Use(s.CORSMiddleware())
 	api.GET("rtc/:channelName/:role/:tokenType/:rtcuid/", s.getRtcToken)
 	api.GET("rtm/:rtmuid/", s.getRtmToken)
 	api.GET("rte/:channelName/:role/:tokenType/:rtcuid/", s.getRtcRtmToken)


### PR DESCRIPTION
This PR adds support for preflight requests, and moves the CORS header logic from the `nochache` to `CORSMiddleware`. 

When developing locally browsers will make a preflight request because even though both the client and token on localhost when running on different ports it will trigger a preflight request. A preflight request is a request made by the browser to the server using the same route but using the OPTIONS request type rather than POST or GET. 

This update uses a custom middleware `CORSMiddleware` to apply the CORS headers and return early when OPTIONS requests are detected.